### PR TITLE
feat: UnderlineTabs 컴포넌트 추가

### DIFF
--- a/src/shared/ui/underline-tabs.tsx
+++ b/src/shared/ui/underline-tabs.tsx
@@ -1,0 +1,67 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/shared/lib/utils"
+
+function UnderLineTabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="underline-tabs"
+      className={cn("flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function UnderLineTabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="underline-tabs-list"
+      className={cn(
+        "inline-flex h-auto w-fit items-center justify-start bg-transparent p-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function UnderLineTabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="underline-tabs-trigger"
+      className={cn(
+        "inline-flex h-12 flex-1 items-center justify-center whitespace-nowrap border-b-2 border-transparent bg-white px-6 py-3 text-base font-medium text-gray-500 transition-all hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-blue-500 data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:text-blue-500",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function UnderLineTabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="underline-tabs-content"
+      className={cn(
+        "mt-6 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { UnderLineTabs, UnderLineTabsList, UnderLineTabsTrigger, UnderLineTabsContent }


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 재사용 가능한 UnderlineTabs 컴포넌트를 shared/ui에 추가

## 주요 변경사항

- **UnderLineTabs**: 메인 탭 컨테이너 컴포넌트
- **UnderLineTabsList**: 탭 버튼들을 감싸는 리스트 컴포넌트  
- **UnderLineTabsTrigger**: 개별 탭 버튼 컴포넌트
- **UnderLineTabsContent**: 탭 콘텐츠 영역 컴포넌트
https://ui.shadcn.com/docs/components/tabs 와 완전히 동일한 API 
---

## 🔗 관련 이슈

closes #24

---

## 📋 체크리스트

- [x] UnderlineTabs 컴포넌트 구현