### PR TITLE
refactor: [FilterModal] 리팩토링하여 좀더 쉽게 사용할 수 있도록 수정

### DIFF
--- a/src/pages/home/ui/FilterMatches/FilterMatchesAction.tsx
+++ b/src/pages/home/ui/FilterMatches/FilterMatchesAction.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export const FilterMatchesAction = ({ onReset, onApplyFilter }: Props) => {
   return (
-    <div className="mt-[15px] flex w-full flex-row gap-[15px]">
+    <div className="flex w-full flex-row gap-[15px]">
       <Button
         size="lg"
         variant="hoverHighlight"

--- a/src/pages/home/ui/FilterMatches/index.tsx
+++ b/src/pages/home/ui/FilterMatches/index.tsx
@@ -44,45 +44,39 @@ export const FilterMatches = ({
   return (
     <FilterModal
       title="매치 검색"
-      dialogContent={
-        <div className="flex h-full flex-col gap-0">
-          <FilterMatchesHeader
-            searchText={searchText}
-            onChangeSearchText={onChangeSearchText}
+      filterDialogHeader={
+        <FilterMatchesHeader
+          searchText={searchText}
+          onChangeSearchText={onChangeSearchText}
+        />
+      }
+      filterDialogContent={
+        <>
+          <FilterMatchesType
+            matchType={filters.matchType}
+            onUpdateMatchType={updateMatchType}
           />
-
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            <div className="flex flex-col gap-[15px] py-[15px]">
-              <FilterMatchesType
-                matchType={filters.matchType}
-                onUpdateMatchType={updateMatchType}
-              />
-
-              <FilterMatchesLocationTime
-                location={filters.location}
-                schedule={filters.schedule}
-                onUpdateLocation={updateLocation}
-                onUpdateSchedule={updateSchedule}
-              />
-
-              <FilterMatchesAboutTeam
-                teamAbility={filters.teamAbility}
-                age={filters.age}
-                gender={filters.gender}
-                onUpdateTeamAbility={updateTeamAbility}
-                onUpdateAge={updateAge}
-                onUpdateGender={updateGender}
-              />
-            </div>
-          </div>
-
-          <div className="border-t border-gray-100 bg-white pt-[15px]">
-            <FilterMatchesAction
-              onReset={handleReset}
-              onApplyFilter={handleApplyFilter}
-            />
-          </div>
-        </div>
+          <FilterMatchesLocationTime
+            location={filters.location}
+            schedule={filters.schedule}
+            onUpdateLocation={updateLocation}
+            onUpdateSchedule={updateSchedule}
+          />
+          <FilterMatchesAboutTeam
+            teamAbility={filters.teamAbility}
+            age={filters.age}
+            gender={filters.gender}
+            onUpdateTeamAbility={updateTeamAbility}
+            onUpdateAge={updateAge}
+            onUpdateGender={updateGender}
+          />
+        </>
+      }
+      filterDialogFooter={
+        <FilterMatchesAction
+          onReset={handleReset}
+          onApplyFilter={handleApplyFilter}
+        />
       }
     />
   );

--- a/src/pages/home/ui/FilterMatches/index.tsx
+++ b/src/pages/home/ui/FilterMatches/index.tsx
@@ -45,37 +45,43 @@ export const FilterMatches = ({
     <FilterModal
       title="매치 검색"
       dialogContent={
-        <div className="flex flex-col gap-[15px]">
+        <div className="flex h-full flex-col gap-0">
           <FilterMatchesHeader
             searchText={searchText}
             onChangeSearchText={onChangeSearchText}
           />
 
-          <FilterMatchesType
-            matchType={filters.matchType}
-            onUpdateMatchType={updateMatchType}
-          />
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-[15px] py-[15px]">
+              <FilterMatchesType
+                matchType={filters.matchType}
+                onUpdateMatchType={updateMatchType}
+              />
 
-          <FilterMatchesLocationTime
-            location={filters.location}
-            schedule={filters.schedule}
-            onUpdateLocation={updateLocation}
-            onUpdateSchedule={updateSchedule}
-          />
+              <FilterMatchesLocationTime
+                location={filters.location}
+                schedule={filters.schedule}
+                onUpdateLocation={updateLocation}
+                onUpdateSchedule={updateSchedule}
+              />
 
-          <FilterMatchesAboutTeam
-            teamAbility={filters.teamAbility}
-            age={filters.age}
-            gender={filters.gender}
-            onUpdateTeamAbility={updateTeamAbility}
-            onUpdateAge={updateAge}
-            onUpdateGender={updateGender}
-          />
+              <FilterMatchesAboutTeam
+                teamAbility={filters.teamAbility}
+                age={filters.age}
+                gender={filters.gender}
+                onUpdateTeamAbility={updateTeamAbility}
+                onUpdateAge={updateAge}
+                onUpdateGender={updateGender}
+              />
+            </div>
+          </div>
 
-          <FilterMatchesAction
-            onReset={handleReset}
-            onApplyFilter={handleApplyFilter}
-          />
+          <div className="border-t border-gray-100 bg-white pt-[15px]">
+            <FilterMatchesAction
+              onReset={handleReset}
+              onApplyFilter={handleApplyFilter}
+            />
+          </div>
         </div>
       }
     />

--- a/src/shared/lib/button-variants.ts
+++ b/src/shared/lib/button-variants.ts
@@ -17,9 +17,9 @@ export const buttonVariants = cva(
           'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
         select:
-          'bg-[#fff] rounded-[5px] text-[16px] font-bold leading-6 border border-[#e0e0e0]',
+          'bg-[#fff] rounded-[5px] text-[16px] font-bold leading-6 border',
         hoverHighlight:
-          'border border-[#eee] bg-white text-[16px] leading-6 font-bold text-[#000] hover:bg-[#4D7FFF] hover:text-white',
+          'border bg-[#EEE] text-[16px] leading-6 font-bold text-[#000] hover:bg-[#4D7FFF] hover:text-white',
         none: 'cursor-pointer',
       },
       size: {

--- a/src/widgets/filter-modal/ui/FilterModal.tsx
+++ b/src/widgets/filter-modal/ui/FilterModal.tsx
@@ -12,12 +12,19 @@ import {
   FilterIcon,
 } from '@/shared';
 
-type Props = {
+type FilterModalProps = {
   title: string;
-  dialogContent: React.ReactNode;
+  filterDialogHeader: React.ReactNode; // 상단 고정
+  filterDialogContent: React.ReactNode; // 스크롤 영역
+  filterDialogFooter: React.ReactNode; // 하단 고정
 };
 
-export const FilterModal = ({ title, dialogContent }: Props) => {
+export const FilterModal = ({
+  title,
+  filterDialogHeader,
+  filterDialogContent,
+  filterDialogFooter,
+}: FilterModalProps) => {
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -41,7 +48,17 @@ export const FilterModal = ({ title, dialogContent }: Props) => {
             <CloseIcon />
           </DialogClose>
         </DialogHeader>
-        <div className="min-h-0 flex-1">{dialogContent}</div>
+        <div className="flex h-full min-h-0 flex-1 flex-col gap-0">
+          {filterDialogHeader}
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-[15px] py-[15px]">
+              {filterDialogContent}
+            </div>
+          </div>
+          <div className="border-t border-gray-100 bg-white pt-[15px]">
+            {filterDialogFooter}
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/widgets/filter-modal/ui/FilterModal.tsx
+++ b/src/widgets/filter-modal/ui/FilterModal.tsx
@@ -30,10 +30,10 @@ export const FilterModal = ({ title, dialogContent }: Props) => {
         </Button>
       </DialogTrigger>
       <DialogContent
-        className="gap-[15px] rounded-[20px] p-[30px]"
+        className="flex h-[90dvh] max-h-235 w-[min(92vw,512px)] flex-col rounded-[20px] bg-white p-[30px]"
         showCloseButton={false}
       >
-        <DialogHeader className="flex flex-row items-center justify-between">
+        <DialogHeader className="mb-[15px] flex flex-shrink-0 flex-row items-center justify-between">
           <DialogTitle className="text-2xl leading-9 font-bold">
             {title}
           </DialogTitle>
@@ -41,7 +41,7 @@ export const FilterModal = ({ title, dialogContent }: Props) => {
             <CloseIcon />
           </DialogClose>
         </DialogHeader>
-        {dialogContent}
+        <div className="min-h-0 flex-1">{dialogContent}</div>
       </DialogContent>
     </Dialog>
   );

--- a/src/widgets/place-search-modal/ui/PlaceSearchModal.tsx
+++ b/src/widgets/place-search-modal/ui/PlaceSearchModal.tsx
@@ -104,7 +104,7 @@ export const PlaceSearchModal = ({
     [onPlaceSelect, onClose]
   );
 
-  const handleKeyPress = useCallback(
+  const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter') {
         handleSearch();
@@ -129,7 +129,7 @@ export const PlaceSearchModal = ({
                 placeholder="장소명 또는 주소를 입력해주세요."
                 value={searchKeyword}
                 onChange={e => setSearchKeyword(e.target.value)}
-                onKeyDown={handleKeyPress} // onKeyPress 대신 onKeyDown 권장
+                onKeyDown={handleKeyDown}
                 className="pr-10"
               />
               <div className="absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 text-gray-400">


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- FilterModal 에 title, filterDialogHeader, filterDialogContent, filterDialogFooter 을 prop으로 줄 수 있도록 하도록 수정
- 이 때 filterDialogContent만 스크롤이 되도록 하고 나머지는 각자 정해진 영역에 고정되어 있도록 함
- 모달의 높이는 화면의 90%이고 최대 940px이 될 수 있도록 함

---

## 🔗 관련 이슈

closes #51 

---

## 📷 스크린샷 (필요한 경우)

<img width="705" height="1225" alt="image" src="https://github.com/user-attachments/assets/cb278199-7f13-47a7-be84-54eb1ded7970" />
<img width="698" height="926" alt="image" src="https://github.com/user-attachments/assets/101b515b-fb06-479e-b9db-d0dbf09f154e" />

---

## 📋 체크리스트

- [ ] 폴더 위치 변경
- [ ] 조건부 처리가 잘되었는지
- [ ] 각 페이지에서 쉽게 사용할 수 있는지

---

## 💬 하고 싶은 말

- 기존에는 prop에 따라 분기 처리를 하여 필터가 매치관련인지 팀 관련인지에 따라 보이는 옵션만 다르게 하도록 수정하려고 했는데 사용하는 옵션이 다른 경우도 있고 복잡도만 올라갈 것 같아서 각 페이지에서 FilterModal의 prop으로 사용할 것들을 관리하는 것이 낫다고 판단하여 스타일링만 해두었습니다.
